### PR TITLE
Fix column name in table data push

### DIFF
--- a/togglwdc.js
+++ b/togglwdc.js
@@ -115,7 +115,7 @@ function pagesCallback(data){
 							"start" : start,
 							"end" : end,
 							"proj" : proj,
-							"tasl" : task,
+							"task" : task,
 							"client" : client,
 							"bill" : bill,
 							"isbill" : isbill,


### PR DESCRIPTION
Noticed task column wasn't being populated, as comes through as "tasl" in table data push